### PR TITLE
Spelling fixes for Journey

### DIFF
--- a/combat.zil
+++ b/combat.zil
@@ -313,7 +313,7 @@ appeared that ">
 
 <CONSTANT AGGRESSION-TBL
 	  <TABLE "a decidedly defensive" "a defensive" "a somewhat defensive"
-		 "a balanced" "an aggressive" "an agressive"
+		 "a balanced" "an aggressive" "an aggressive"
 		 "a boldly aggressive" "an all-out aggressive"
 		 "an almost suicidally aggressive">>
 

--- a/fog.zil
+++ b/fog.zil
@@ -272,7 +272,7 @@ completely buried his only known route to the outside.">
 			<TELL "only">)
 		       (T
 			<TELL " and">)>
-		 <TELL " his magical paraphenalia - his staff and pouch of powders.">
+		 <TELL " his magical paraphernalia - his staff and pouch of powders.">
 		 <UPDATE-FSET ,HERE ,INVENTORIED>)
 		(DROP
 		 <COND (<EQUAL? ,HERE ,XFER-1-ANTE ,XFER-2-ANTE ,XFER-3-ANTE>

--- a/forest.zil
+++ b/forest.zil
@@ -1793,7 +1793,7 @@ trees and out of sight. Discouraged, I returned to our camp.">
 		(EXAMINE:REMOVE
 		 <TELL ACT
 " stopped to admire the surrounding pine and alder. But up ahead, the forest
-appeared darker and more forebidding.">)>)>
+appeared darker and more forbidding.">)>)>
 
 <OBJECT TANGLETREE
 	(LOC TANGLEWOOD)

--- a/hints.zil
+++ b/hints.zil
@@ -906,7 +906,7 @@ I will never know what lay along that path.">)
 that we never found a way across. Could that have helped?">)
 			(<NOT <FSET? ,SUNSET-TOWER ,SOLVED>>
 			 <TELL
-"The Sunset Tower: why do I feel that we have missed simething there? Was
+"The Sunset Tower: why do I feel that we have missed something there? Was
 there something hidden there?">)
 			(T
 			 <TELL

--- a/hints.zil
+++ b/hints.zil
@@ -154,7 +154,7 @@ cave and the pool we had found within it.">)
 			 ;"Didn't hide..."
 			 <TELL
 "If only I could have avoided the strange creatures that had captured " D
-,LAKE-VICTIM ". I may have inadvertantly worsened my chances by allowing
+,LAKE-VICTIM ". I may have inadvertently worsened my chances by allowing
 myself to have been seen by one of them earlier.">)
 			(,NYMPHS-COMING?
 			 <TELL

--- a/hints.zil
+++ b/hints.zil
@@ -319,7 +319,7 @@ surrounding his acquisition of the mysterious map we purchased.">)
 Webba's meant. Perhaps if we had spoken to him, he would have explained.">)
 	       (T
 		<TELL
-"I don't know how we might have avoided the grizzly scene at the Sunrise
+"I don't know how we might have avoided the grisly scene at the Sunrise
 Mountain. We had no map, and all paths looked similar. Perhaps it was
 unavoidable.">)>
 	 <UPDATE-REMOVE ,ACTION-OBJECT>>

--- a/hints.zil
+++ b/hints.zil
@@ -508,7 +508,7 @@ I must not judge him too harshly.")>
 	(SDESC "Umber")
 	(KBD %<ASCII !\U>)
 	(SOLUTION
-"Why did Praxix refuse Umber's offer to join him? Pride? Stubborness? I
+"Why did Praxix refuse Umber's offer to join him? Pride? Stubbornness? I
 suppose we shall never know.")>
 
 <OBJECT HINT-DUNGEON

--- a/lake.zil
+++ b/lake.zil
@@ -132,7 +132,7 @@ the stream until we came to the shore of the lake.">
 		      <TELL
 "Praxix, taking out his air and earth essences, cast his elevation spell on "
 D ,ACTION-PRSI ", who rose slowly into the air before us. Still, the onrushing
-waters approached, and I tried desparately to get away. ">
+waters approached, and I tried desperately to get away. ">
 		      <TORRENT-HITS>
 		      <RTRUE>)>)
 	      (PROCEED

--- a/lake.zil
+++ b/lake.zil
@@ -1279,7 +1279,7 @@ peering with difficulty through the cloudy waters">
 			<COND (<IN? ,NYMPH-STONE ,UL-PIT-BOTTOM>
 			       <TELL
 " But then, at the bottom of the pool, in the midst of the unspeakable filth,
-I caught a glimpse of the the amulet I had taken from the treasury">
+I caught a glimpse of the amulet I had taken from the treasury">
 			       <COND (<G? ,UL-DROPPED 0>
 				      <TELL ", but nothing else">)>
 			       <TELL ".">)

--- a/lake.zil
+++ b/lake.zil
@@ -719,7 +719,7 @@ the blanket which covered him heaved slowly with his breath, and for this,
 I was greatly relieved.">
 		<COND (<FSET? ,HERE ,EXAMINED>
 		       <TELL CR CR
-"But as I knelt beside him, my foot inadvertantly caught the end of the
+"But as I knelt beside him, my foot inadvertently caught the end of the
 blanket, and pulled it to the floor. " D ,LAKE-VICTIM " was not only unconscious,
 but his feet and hands had been tightly bound!">)>
 		<TELL

--- a/lake.zil
+++ b/lake.zil
@@ -1266,7 +1266,7 @@ D ,LAKE-VICTIM ". Thankfully, he was conscious.">)
 "As I dove into the water, I was filled with amazement that the torch I was carrying
 had not been extinguished. If anything, it appeared to glow more brightly, and the flame
 became warmer. Soon, I had reached the bottom of the pool, which was covered with
-every sort of putrifying debris you can imagine, and some that you probably couldn't.
+every sort of putrefying debris you can imagine, and some that you probably couldn't.
 Decaying debris lowered the visibility considerably, making it difficult to gauge
 anything much about the pool itself.">)
 			      (T

--- a/lavos.zil
+++ b/lavos.zil
@@ -411,7 +411,7 @@ Mountain,\" he said, \"we should have better luck keeping to the left.\"">)
 		      <TELL
 "It felt like hours had passed while we stood at the fork, looking this way
 and that, not knowing which would lead more quickly to our destination. Perhaps
-it would not matter, yet we feared that time was critial and that our decision
+it would not matter, yet we feared that time was critical and that our decision
 here would be crucial to our success.">)>)
 	      (SCOUT:REMOVE
 	       <COND (<EQUAL? ,ACTOR ,ESHER>

--- a/mines.zil
+++ b/mines.zil
@@ -53,7 +53,7 @@ dissuaded by ">
 		      <TELL 
 "Hurth. \"The principal route through this level heads to
 the north up ahead; there is no point in turning back, lest we
-foresake our purpose.\"">)
+forsake our purpose.\"">)
 		     (T
 		      <TELL
 "Praxix. \"We have no choice, if we are to find the Stone, but to

--- a/part2.zil
+++ b/part2.zil
@@ -212,7 +212,7 @@ suspicious shadows that his staff now cast upon the rocks." CR CR>
 \"But these caverns teem with orcs, and we cannot be too careful. Yes,
 now that I look again, I believe Praxix is right.\"" CR CR>
 		      <TELL
-"Just then, in pointed contradition to my elder's conclusions,">)>
+"Just then, in pointed contradiction to my elder's conclusions,">)>
 	       <TELL
 " a man stepped from the shadows, his face glowing in the pale light of
 Praxix' outstretched staff." CR CR>

--- a/river.zil
+++ b/river.zil
@@ -209,7 +209,7 @@ we reached an outcropping high above a towering falls.">
 		       <TELL CR CR
 "\"It's wonderful!\" I said. \"No, not wonderful.\" Esher replied,
 frowning. \"Dangerous... deadly...\" He had turned pale, almost
-ashen, as he spoke, his eyes tranfixed on the torrent that
+ashen, as he spoke, his eyes transfixed on the torrent that
 roared beneath us.">)>
 		<COND (<AND <IN? ,RAFT ,RIVER-3>
 			    <IN-PARTY? ,BERGON>

--- a/stair.zil
+++ b/stair.zil
@@ -129,7 +129,7 @@ and we decided to stop in a nearby clearing for some lunch.">
 	       <GATE-TO-HIGH-PLAIN>)
 	      (DOWN:REMOVE
 	       <TELL
-"Uncertain of whether we had explored enough of these caverns, we decended
+"Uncertain of whether we had explored enough of these caverns, we descended
 to the junction of the two stairs.">
 	       <MOVE-TO ,STAIR-JUNCTION>)>)>
 

--- a/tomb.zil
+++ b/tomb.zil
@@ -178,7 +178,7 @@ D .TMP " still trapped inside the darkened hole." CR CR>
 with my roommate here, if you know what I mean!\"" CR CR>
 		      <TELL
 "As " <I/WE> " prepared to leave, " D ,HOLE-VICTIM " screamed loudly, and "
-<I/WE> " heard nothing further from within the hole. In all likelyhood, "
+<I/WE> " heard nothing further from within the hole. In all likelihood, "
 D ,HOLE-VICTIM " was dead. ">
 		      <COND (<EQUAL? .TMP ,PRAXIX>
 			     <TELL CR CR

--- a/trap.zil
+++ b/trap.zil
@@ -473,7 +473,7 @@ remained, giving them to Praxix." CR CR>)
 			     (T
 			      <TELL
 "I admitted that I did not, having used them both in saving " D ,TRAP-VICTIM
-" from almost certin death at the hands of the orcs." CR CR>
+" from almost certain death at the hands of the orcs." CR CR>
 			      <TELL
 "\"Then you have used them well,\" Praxix replied reassuringly, \"I
 would happily take " D ,TRAP-VICTIM " over any number of magical

--- a/trap.zil
+++ b/trap.zil
@@ -262,7 +262,7 @@ in my pack which would help.">
 " To my astonishment, I came up literally empty-handed, for as I pulled my
 hand from the pack, I found it to be entirely transparent. And then I
 put two pieces together: the disappearing miner and the pieces of red rock
-that had inadvertantly fallen from his sack." CR CR>
+that had inadvertently fallen from his sack." CR CR>
 		      <TELL
 "Reaching back into the pack, I noticed that some powder had been scraped
 off one of the red rocks. \"A magical reagent!\" I said to myself, proud to have

--- a/voyage.zil
+++ b/voyage.zil
@@ -522,7 +522,7 @@ time for parlor magicians,\" he said mockingly.">
 		 <TELL
 "\"He's not hurt badly,\" he said." CR CR>
 		 <TELL
-"\"How very thoughful you are, " ACT ",\" the demon boomed. \"But do not concern
+"\"How very thoughtful you are, " ACT ",\" the demon boomed. \"But do not concern
 yourself, for I shall not kill your Wizard friend - at least not yet. But now to
 business.\"">)>)>
 

--- a/wharf.zil
+++ b/wharf.zil
@@ -136,7 +136,7 @@ Stout. He'll be back before spring, I expect.\"" CR CR>
 	       <END-OPTION>)
 	      (NO
 	       <TELL
-"\"Let me suggest you ask the captains of the Elventide, over there, and
+"\"Let me suggest you ask the captains of the Elfentide, over there, and
 the South Seas, over there,\" he said, pointing out the two boats.">
 	       <TRAVEL-COMMANDS ,HERE
 				,ELFENTIDE-COMMAND

--- a/zan.zil
+++ b/zan.zil
@@ -646,7 +646,7 @@ on the sign were the words, \"Rest Easy,\" nothing more." CR CR>
 hypnotic movement, \"and it is getting rather late.\"">)>)>
 
 <CONSTANT COMFORTABLE-SPOT
-" a comfortable spot ouside
+" a comfortable spot outside
 of town to pitch our tents. The offshore breeze kept the air comfortably
 cool, and we were fast asleep within minutes.">
 


### PR DESCRIPTION
These are the spelling fixes for Journey from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.